### PR TITLE
Changed version number in pom to 1.1.0 and added wagon extension for ssh access to maven repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.hh</groupId>
     <artifactId>RequestDispatcher</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <name>RequestDispatcher</name>
@@ -65,7 +65,13 @@
     </dependencies>
 
      <build>
-        <plugins>
+       <extensions>
+	 <extension>
+	   <groupId>org.apache.maven.wagon</groupId>
+	   <artifactId>wagon-ssh</artifactId>
+	 </extension>
+       </extensions>
+       <plugins>
         <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
             <version>2.3.2</version>


### PR DESCRIPTION
hey heinrich I just gave you a new version number which has also been used to deploy your changes to our maven repository: http://develop.metalcon.de:8080/mvn/ . I needed to use the wagon extension again
